### PR TITLE
Update Autocomplete.js

### DIFF
--- a/src/autoComplete/Autocomplete.js
+++ b/src/autoComplete/Autocomplete.js
@@ -177,7 +177,7 @@ const AutoComplete = props => {
           multiline={selectedItem ? true : false}
           onFocus={handleOnFocus}
           onBlur={() => setIsFocused(false)}
-          clearTextOnFocus="true"
+          clearTextOnFocus={true}
           underlineColorAndroid={isFocused ? defaultAccentColor : '#C7C1CB'}
         />
 


### PR DESCRIPTION
Fix bug:
Warning: Failed prop type: Invalid prop `clearTextOnFocus` of type `string` supplied to `ForwardRef(TextInput)`, expected `boolean`.
TextInput